### PR TITLE
Use current time when checking prediction locks

### DIFF
--- a/pages/PredictionsPage.tsx
+++ b/pages/PredictionsPage.tsx
@@ -96,11 +96,12 @@ const PredictionsPage: React.FC = () => {
 
   useEffect(() => {
     if (!gp) return;
-    
-    const now = new Date();
-    const getLockTime = (eventTime: string) => new Date(new Date(eventTime).getTime() - LOCK_MINUTES_BEFORE * 60 * 1000);
+
+    const getLockTime = (eventTime: string) =>
+        new Date(new Date(eventTime).getTime() - LOCK_MINUTES_BEFORE * 60 * 1000);
 
     const checkLocks = () => {
+        const now = new Date();
         setLocks({
             quali: now > getLockTime(gp.events.quali),
             sprint: gp.hasSprint && gp.events.sprint ? now > getLockTime(gp.events.sprint) : true,


### PR DESCRIPTION
## Summary
- Recalculate prediction locks using a fresh timestamp inside `checkLocks`
- Preserve periodic re-evaluation every 30 seconds

## Testing
- `node` script to observe `locks` state transition over time
- `npm run build` *(fails: Could not resolve "../services/geminiService" from "pages/AdminPage.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68af15947eb88321a81f191ae525b9a3